### PR TITLE
IR 2923 (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# DiagramBuilder Add-on for Vaadin 7 - Continuum Security Fork
-
-[![](https://jitpack.io/v/continuumsecurity/diagram-builder.svg)](https://jitpack.io/#continuumsecurity/diagram-builder/)
+# DiagramBuilder Add-on for Vaadin 8 - Continuum Security Fork
 
 > This repository uses the a forked Alloy-ui library generated from this repository: [Alloy-ui forked reporisoty](https://github.com/continuumsecurity/alloy-ui)
 
@@ -21,6 +19,11 @@ DiagramBuilder diagramBuilder = new DiagramBuilder();
 diagramBuilder.setShowDeleteNodeIcon(false);
 diagramBuilder.setEnableDeleteByKeyStroke(false);
 ```
+
+### Upgrade Vaadin version from 7.6.1 to 8.5.2
+Continuum security use Vaadin 8.5.2 and some errors were spotted using an older version, so we decided to update from
+vaadin 7 to 8 since release [1.4.1](https://github.com/continuumsecurity/diagram-builder/releases/tag/1.4.1)
+To use the previous version with vaadin 7 support pick the release [1.4.0](https://github.com/continuumsecurity/diagram-builder/releases/tag/1.4.0)
 
 ### Upgrade Vaadin version from 7.2.0.beta1 to 7.6.1
 Continuum security use Vaadin 7.6.1 and some errors were spotted when using an older version
@@ -89,6 +92,9 @@ To see the demo, navigate to http://localhost:8080/
 
  
 ## Release notes
+
+### Version 1.4.1
+* Upgrade Vaadin version from 7.6.1 to 8.5.2
 
 ### Version 1.21
 * Upgrade Vaadin version from 7.2.0.beta1 to 7.6.1

--- a/diagram-builder-demo/pom.xml
+++ b/diagram-builder-demo/pom.xml
@@ -5,13 +5,13 @@
 	<groupId>org.vaadin</groupId>
 	<artifactId>diagram-builder-demo</artifactId>
 	<packaging>war</packaging>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
 	<name>DiagramBuilder Add-on Demo</name>
     <url>https://github.com/continuumsecurity/diagram-builder</url>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>7.6.1</vaadin.version>
+		<vaadin.version>8.5.2</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
     </properties>
         
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.vaadin</groupId>
             <artifactId>diagram-builder</artifactId>
-            <version>1.4.0</version>
+            <version>1.4.1</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
@@ -105,12 +105,6 @@
             <artifactId>javax.servlet-api</artifactId>
             <version>3.0.1</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.peimari</groupId>
-            <artifactId>maddon</artifactId>
-            <version>1.4</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/diagram-builder-demo/src/main/java/org/vaadin/diagrambuilder/demo/DemoUI.java
+++ b/diagram-builder-demo/src/main/java/org/vaadin/diagrambuilder/demo/DemoUI.java
@@ -11,14 +11,13 @@ import com.vaadin.server.VaadinServlet;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Notification;
 import com.vaadin.ui.UI;
+import com.vaadin.ui.VerticalLayout;
 
 import org.vaadin.diagrambuilder.DiagramBuilder;
 import org.vaadin.diagrambuilder.DiagramStateEvent;
 import org.vaadin.diagrambuilder.domain.Node;
 import org.vaadin.diagrambuilder.domain.NodeType;
 import org.vaadin.diagrambuilder.domain.Transition;
-import org.vaadin.maddon.label.RichText;
-import org.vaadin.maddon.layouts.MVerticalLayout;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,8 +60,6 @@ public class DemoUI extends UI {
         diagramBuilder.addGroupRightClickListener(nodeDto -> Notification.show("Group Right click " + nodeDto.getName(), Notification.Type.WARNING_MESSAGE));
         diagramBuilder.addGroupDragEndListener(nodeDto -> Notification.show("Group Drag ends " + nodeDto.getName(), Notification.Type.WARNING_MESSAGE));
         diagramBuilder.addGroupDragStartListener(nodeDto -> Notification.show("Group Drag starts " + nodeDto.getName(), Notification.Type.WARNING_MESSAGE));
-        diagramBuilder.addTaskMouseOverListener(nodeDto -> Notification.show("Task Mouse OVER " + nodeDto.getName(), Notification.Type.WARNING_MESSAGE));
-        diagramBuilder.addTaskMouseOutListener(nodeDto -> Notification.show("Task Mouse OUT " + nodeDto.getName(), Notification.Type.WARNING_MESSAGE));
 
         diagramBuilder.addTaskRightClickListener(nodeDto -> Notification.show("Task Right click " + nodeDto.getName(), Notification.Type.WARNING_MESSAGE));
         diagramBuilder.addTaskMouseOverListener(nodeDto -> Notification.show("Task Mouse OVER " + nodeDto.getName(), Notification.Type.WARNING_MESSAGE));
@@ -70,13 +67,7 @@ public class DemoUI extends UI {
         diagramBuilder.addTaskDragStartListener(nodeDto -> Notification.show("Task Drag Start " + nodeDto.getName(), Notification.Type.WARNING_MESSAGE));
         diagramBuilder.addTaskDragEndListener(nodeDto -> Notification.show("Task Drag END " + nodeDto.getName(), Notification.Type.WARNING_MESSAGE));
 
-        setContent(
-                new MVerticalLayout(
-                        new RichText().withMarkDownResource("/intro.md"),
-                        button,
-                        diagramBuilder
-                )
-        );
+        setContent(new VerticalLayout(button, diagramBuilder));
     }
 
     private void initDiagramBuilder(DiagramBuilder diagramBuilder) {

--- a/diagram-builder/pom.xml
+++ b/diagram-builder/pom.xml
@@ -4,13 +4,13 @@
     <groupId>org.vaadin</groupId>
     <artifactId>diagram-builder</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
     <name>diagram-builder</name>
     <url>https://github.com/continuumsecurity/diagram-builder</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>7.6.1</vaadin.version>
+        <vaadin.version>8.5.2</vaadin.version>
         <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 
         <!-- ZIP Manifest fields -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin</groupId>
 	<artifactId>diagram-builder-root</artifactId>
 	<packaging>pom</packaging>
-	<version>1.4.0</version>
+	<version>1.4.1</version>
 	<name>DiagramBuilder Add-on Root Project</name>
 
 	<modules>


### PR DESCRIPTION
* [IR-2923] - upgrade to 1.4.1 version to support vaadin 8.

* [IR-2923] - add a release notes.

* [IR-2923] - set 1.4.1 as a stable version.

* [IR-2923] Update diagram builder demo